### PR TITLE
Support adding non-English common names

### DIFF
--- a/db/sql/types/add.sql
+++ b/db/sql/types/add.sql
@@ -5,6 +5,8 @@ INSERT INTO types (
   en_synonyms,
   scientific_name,
   scientific_synonyms,
+  ar_name, de_name, el_name, es_name, fr_name, he_name, it_name, nl_name,
+  pl_name, pt_br_name, sk_name, sv_name, tr_name, zh_tw_name,
   taxonomic_rank,
   notes,
   category_mask
@@ -16,6 +18,8 @@ VALUES (
   ${en_synonyms},
   ${scientific_name},
   ${scientific_synonyms},
+  ${ar_name}, ${de_name}, ${el_name}, ${es_name}, ${fr_name}, ${he_name}, ${it_name}, ${nl_name},
+  ${pl_name}, ${pt_br_name}, ${sk_name}, ${sv_name}, ${tr_name}, ${zh_tw_name},
   ${taxonomic_rank},
   ${notes},
   ${category_mask}
@@ -35,4 +39,5 @@ RETURNING
   pl_name, pt_br_name, sk_name, sv_name, tr_name, zh_tw_name,
   eat_the_weeds_url, foraging_texas_url, fruitipedia_url, urban_mushrooms_url, wikipedia_url,
   usda_symbol,
-  category_mask
+  category_mask,
+  notes

--- a/db/sql/types/list.sql
+++ b/db/sql/types/list.sql
@@ -7,5 +7,6 @@ SELECT
   pl_name, pt_br_name, sk_name, sv_name, tr_name, zh_tw_name,
   eat_the_weeds_url, foraging_texas_url, fruitipedia_url, urban_mushrooms_url, wikipedia_url,
   usda_symbol,
-  category_mask
+  category_mask,
+  notes
 FROM types

--- a/db/sql/types/show.sql
+++ b/db/sql/types/show.sql
@@ -7,6 +7,7 @@ SELECT
   pl_name, pt_br_name, sk_name, sv_name, tr_name, zh_tw_name,
   eat_the_weeds_url, foraging_texas_url, fruitipedia_url, urban_mushrooms_url, wikipedia_url,
   usda_symbol,
-  category_mask
+  category_mask,
+  notes
 FROM types
 WHERE id = ${id}

--- a/docs/components/schemas.yml
+++ b/docs/components/schemas.yml
@@ -119,7 +119,7 @@ BaseType:
       nullable: true
       example: 8
     common_names:
-      description: Common names, starting with the preferred synonym, by language code (e.g. `en`) and optional region code (e.g. `en_us`). Currently, only `en` can be set.
+      description: Common names, starting with the preferred synonym, by language code. Use `pt_br` for Portuguese (Brazilian or otherwise). Use `zh_tw` for traditional Chinese characters. Any language not in the example is read and written to the notes. If no scientific name or English (`en`) common name is provided, the first common name is used as the default name.
       type: object
       additionalProperties:
         type: array

--- a/helpers.js
+++ b/helpers.js
@@ -201,6 +201,16 @@ _.format_type = function(type) {
       }
     }
   }
+  // Extract common names from notes
+  if (type.notes) {
+    const regex = /^common_names\.([a-z]{2}(?:_[a-z]{2})?): ([^\n]+)$/gm
+    let match
+    while ((match = regex.exec(type.notes)) !== null) {
+      const [_, locale, names] = match
+      type.common_names[locale] = names.split(', ')
+    }
+  }
+  delete type.notes
   // Append English synonyms
   if (type.en_synonyms) {
     const synonyms = type.en_synonyms.split(', ')
@@ -226,18 +236,23 @@ _.format_type = function(type) {
   return type
 }
 
+_.locale_to_name = function(locale) {
+  const prefix = locale.toLowerCase().replace('-', '_')
+  return `${prefix}_name`
+}
+
 _.deconstruct_type = function(type) {
-  // TODO: Handle additional locales
   if (type.common_names) {
+    // Extract English name and synonyms
     if ('en' in type.common_names) {
       type.en_name = type.common_names.en[0]
-      type.en_synonyms = type.common_names.en.slice(1).join(', ')
+      type.en_synonyms = type.common_names.en.slice(1).join(', ') || null
+      delete type.common_names['en']
     }
-    delete type.common_names
   }
   if (type.scientific_names) {
     type.scientific_name = type.scientific_names[0]
-    type.scientific_synonyms = type.scientific_names.slice(1).join(', ')
+    type.scientific_synonyms = type.scientific_names.slice(1).join(', ') || null
     delete type.scientific_names
   }
   if (type.categories) {


### PR DESCRIPTION
* Adds support for storing non English (`en`) common names
* If no English common name or scientific name is provided, the first common name is (pending review) also used as the default (English) common name
* As a temporary measure, locales without a `types.{locale}_name` column are written to (and read from) `notes`. Following the website migration, common names will be moved to a separate table

Closes #33 .